### PR TITLE
Complete revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,43 +25,18 @@ You must have the following environment variables set:
 
 # Under the Hood
 
-This is a very skinny server. It exposes an interface to create status indicators, like this:
+This is a very skinny server. It exposes an interface to create status indicators. You can add a new indicator like this:
 
 ```javascript
-// Travis CI builds to monitor.
-_.each({
-    'numenta/nupic': 'NuPIC Travis CI',
-    'numenta/nupic.core': 'NuPIC Core Travis CI',
-    'numenta/nupic.regression': 'NuPIC Regression Tests'
-}, function(title, slug) {
-    statusFetchers.push(function(callback) {
-        var status = {
-            name: title,
-            link: 'https://travis-ci.org/' + slug,
-            category: categories.OS
-        };
-        getLastTravisMasterBuildState(slug, function(err, state) {
-            if (err) {
-                status.status = stateToStatus('unknown');
-                status.description = 'unknown';
-                return callback(null, status);
-            }
-            status.description = state;
-            status.status = stateToStatus(state);
-            callback(null, status);
-        });
-    });
+statusFetchers.push(function(callback) {
+    callback({
+         name: "this will be displayed on the status board as the title of this report"
+       , status: "success,failure,error,pending,unknown"
+       , description: "a more detailed description, as long as you want i guess"
+       , link: "a url to more details"
+       , category: "choose one from options in `categories` in oncall-board.js"
+     });
 });
 ```
 
-This snippet shows the configuration objects first, then the function that will process each config object. The function must call the callback with a status object with these keys:
-
-```javascript
-{
-    name: "this will be displayed on the status board as the title of this report"
-  , status: "success,failure,error,pending,unknown"
-  , description: "a more detailed description, as long as you want i guess"
-  , link: "a url to more details"
-  , category: "choose one from options in `categories` in oncall-board.js"
-}
-```
+The function must call the callback with a status object described above.

--- a/README.md
+++ b/README.md
@@ -22,3 +22,46 @@ You must have the following environment variables set:
 
     npm start
     open http://localhost:${PORT}
+
+# Under the Hood
+
+This is a very skinny server. It exposes an interface to create status indicators, like this:
+
+```javascript
+// Travis CI builds to monitor.
+_.each({
+    'numenta/nupic': 'NuPIC Travis CI',
+    'numenta/nupic.core': 'NuPIC Core Travis CI',
+    'numenta/nupic.regression': 'NuPIC Regression Tests'
+}, function(title, slug) {
+    statusFetchers.push(function(callback) {
+        var status = {
+            name: title,
+            link: 'https://travis-ci.org/' + slug,
+            category: categories.OS
+        };
+        getLastTravisMasterBuildState(slug, function(err, state) {
+            if (err) {
+                status.status = stateToStatus('unknown');
+                status.description = 'unknown';
+                return callback(null, status);
+            }
+            status.description = state;
+            status.status = stateToStatus(state);
+            callback(null, status);
+        });
+    });
+});
+```
+
+This snippet shows the configuration objects first, then the function that will process each config object. The function must call the callback with a status object with these keys:
+
+```javascript
+{
+    name: "this will be displayed on the status board as the title of this report"
+  , status: "success,failure,error,pending,unknown"
+  , description: "a more detailed description, as long as you want i guess"
+  , link: "a url to more details"
+  , category: "choose one from options in `categories` in oncall-board.js"
+}
+```

--- a/oncall-board.js
+++ b/oncall-board.js
@@ -1,35 +1,20 @@
 var path = require('path');
 var fs = require('fs');
 var request = require('request');
-var proxyRequest = request;
 var async = require('async');
 var _ = require('lodash');
 var Handlebars = require('handlebars');
-var GH_USERNAME = process.env.GH_USERNAME;
-var GH_PASSWORD = process.env.GH_PASSWORD;
-var AppVeyor = require('appveyor-js-client');
 var mainTmpl = Handlebars.compile(
     fs.readFileSync(
         path.join(__dirname, 'templates/main.hbt')
     ).toString()
 );
 var statusFetchers = [];
-var appveyor = new AppVeyor('numenta');
-var appveyorProjects = undefined;
-
-var BAMBOO_URL = encodeURI('https://ci.numenta.com/rest/api/latest/result.json');
-var bambooJobs = undefined;
-
-//var JIRA_USER = process.env.JIRA_USERNAME;
-//var JIRA_PASS = process.env.JIRA_PASSWORD;
-//var JQL = 'status in (New, "In Progress", Reopened, Blocked, "Selected for Development", "Ready for Development", "In Review") AND priority in ("P1 - Critical", "P2 - Blocker")';
-//var JIRA_URL = encodeURI('http://' + JIRA_USER + ':' + JIRA_PASS + '@jira.numenta.com/rest/api/2/search?jql=' + JQL);
-
-var categories = {
-    OS: 'Core OS Pipelines',
-    JENKINS: 'Jenkins',
-    BAMBOO: 'Bamboo',
-    PING: 'Ping'
+var CI_STATUS_URL = 'http://nubot.numenta.org/hubot/ci-status';
+var CI_PLATS = {
+    'Bamboo': ['Linux']
+  , 'TravisCI': ['OS X']
+  , 'AppVeyor': ['Windows']
 };
 
 // Set up FIXIE proxying. This is so we can call into AWS for Jenkins/JIRA APIs
@@ -40,83 +25,88 @@ proxyRequest = request.defaults({
 });
 
 function stateToStatus(state) {
-    var numIssues;
-    if (_.endsWith(state, 'issues')) {
-        numIssues = parseInt(state.split(/\s+/).shift());
-        if (numIssues > 5) {
-            return 'danger';
-        } else {
-            return 'warning';
-        }
-    }
     switch(state) {
-        case 'passed':
         case 'success':
-        case 'blue':
-        case 'blue_anime':
+        case 'passed':
         case 'up':
         case 'identical':
         case 'Successful':
             return 'success';
+        case 'failure':
+        case 'failed':
+        case 'Failed':
+            return 'failure';
+        case 'error':
+        case 'errored':
+        case 'err':
+            return 'error';
+        case 'pending':
         case 'started':
         case 'running':
         case 'queued':
         case 'created':
-            return 'info';
-        case 'warning':
-        case 'yellow':
-        case 'yellow_anime':
-        case 'unknown':
-            return 'warning';
+            return 'pending';
         default:
-            return 'danger';
+            console.warn('Unknown state "%s"', state);
+            return 'unknown';
     }
 }
 
-function getLastTravisMasterBuildState(slug, callback) {
-    var url = 'https://api.travis-ci.org/repos/' + slug + '/branches/master';
-    request.get(url, function(err, payload) {
-        if (err) { return callback(err); }
-        callback(null, JSON.parse(payload.body).branch.state);
-    });
-}
+// TODO: important
+// , 'TAUR-TAUR': 'Taurus (Bamboo)'
+// , 'UN-UN': 'Unicorn (Bamboo)'
 
-function getAppVeyorProject(slug, callback) {
-    if (! appveyorProjects) {
-        appveyor.getProjects(function(err, projects) {
-            if (err) { return callback(err); }
-            var target = _.find(projects, function(project) {
-                return project.repoSlug == slug;
+// Gets complete CI status from Nubot service.
+statusFetchers.push(function(callback) {
+    request.get(CI_STATUS_URL, function(err, response, body) {
+        if (err) return callback(err);
+        var statuses = []
+          , payload = JSON.parse(body)
+          ;
+        _.each(payload, function(builds, slug) {
+            _.each(builds, function(build, ciPlatform) {
+                var status = {}
+                  , platforms = CI_PLATS[ciPlatform].join(',')
+                  ;
+                status.name = platforms + ' (' + ciPlatform + ')';
+                status.status = stateToStatus(build.state);
+                status.description = build.state;
+                status.link = build.url;
+                status.category = slug;
+                statuses.push(status);
             });
-            callback(null, target);
         });
-    } else {
-        callback(null, appveyorProjects);
-    }
-}
-
-function findTargetBambooJob(name, callback) {
-    var targetJob = _.find(bambooJobs, function(job) {
-        return job.plan.key == name;
+        callback(null, statuses);
     });
-    callback(null, targetJob);
-}
+});
 
-function getBambooJob(name, callback) {
-    if (! bambooJobs) {
-        proxyRequest.get(BAMBOO_URL, function(err, response) {
-            if (err) return callback(err);
-            try {
-                bambooJobs = JSON.parse(response.body).results.result;
-            } catch(error) {
-                return callback(error);
-            }
-            findTargetBambooJob(name, callback);
-        });
-    } else {
-        findTargetBambooJob(name, callback);
-    }
-}
+
+// URLs we want to monitor.
+//_.each([
+//    'http://numenta.com',
+//    'http://numenta.org',
+//    'http://data.numenta.org',
+//    'http://tooling.numenta.org/status/',
+//    'https://discourse.numenta.org/'
+//], function(url) {
+//    statusFetchers.push(function(callback) {
+//        var status = {
+//            name: url,
+//            link: url,
+//            category: categories.PING
+//        };
+//        request.get(url, function(err, response) {
+//            var state = 'up';
+//            if (err || response.statusCode != 200) {
+//                state = 'down';
+//            }
+//            status.description = state;
+//            status.status = stateToStatus(state);
+//            callback(null, status);
+//        });
+//    });
+//});
+
 
 function sortReportsByCategory(reports) {
     var out = {};
@@ -130,137 +120,10 @@ function sortReportsByCategory(reports) {
     return out;
 }
 
-// Travis CI builds to monitor.
-_.each({
-    'numenta/nupic': 'NuPIC Travis CI',
-    'numenta/nupic.core': 'NuPIC Core Travis CI',
-    'numenta/nupic.regression': 'NuPIC Regression Tests'
-}, function(title, slug) {
-    statusFetchers.push(function(callback) {
-        var status = {
-            name: title,
-            link: 'https://travis-ci.org/' + slug,
-            category: categories.OS
-        };
-        getLastTravisMasterBuildState(slug, function(err, state) {
-            if (err) {
-                status.status = stateToStatus('unknown');
-                status.description = 'unknown';
-                return callback(null, status);
-            }
-            status.description = state;
-            status.status = stateToStatus(state);
-            callback(null, status);
-        });
-    });
-
-});
-
-// AppVeyor builds to monitor
-_.each({
-    'numenta/nupic': 'NuPIC AppVeyor',
-    'numenta/nupic.core': 'NuPIC Core AppVeyor'
-}, function(title, slug) {
-    statusFetchers.push(function(callback) {
-        var status = {
-            name: title,
-            link: 'https://ci.appveyor.com/project/numenta-ci/' + slug.split('/').pop() + '/history',
-            category: categories.OS
-        };
-        getAppVeyorProject(slug, function (err, project) {
-            if (err) {
-                status.status = stateToStatus('unknown');
-                status.description = 'unknown';
-                return callback(null, status);
-            }
-            project.getLastBuildBranch('master', function (err, response) {
-                if (err) {
-                    return callback(err);
-                }
-                status.description = response.build.status;
-                status.status = stateToStatus(response.build.status);
-                callback(null, status);
-            });
-        });
-    });
-});
-
-// Adds status fetchers for each Bamboo job we want to monitor
-_.each({
-    'NUP-PY': 'NuPIC',
-    'NUP-CORE': 'NuPIC Core',
-    'TAUR-TAUR': 'Taurus',
-    'UN-UN': 'Unicorn'
-}, function(title, jobName) {
-    statusFetchers.push(function(callback) {
-        var status = {
-            name: title,
-            category: categories.BAMBOO
-        };
-        getBambooJob(jobName, function(err, job) {
-            if (err) {
-                status.status = stateToStatus('unknown');
-                status.description = 'unknown';
-                return callback(null, status);
-            }
-            status.description = job.state;
-            status.status = stateToStatus(job.state);
-            status.link = job.link.href;
-            callback(null, status);
-        });
-    });
-});
-
-// URLs we want to monitor.
-_.each([
-    'http://numenta.com',
-    'http://numenta.org',
-    'http://data.numenta.org',
-    'http://tooling.numenta.org/status/',
-    'https://discourse.numenta.org/'
-], function(url) {
-    statusFetchers.push(function(callback) {
-        var status = {
-            name: url,
-            link: url,
-            category: categories.PING
-        };
-        request.get(url, function(err, response) {
-            var state = 'up';
-            if (err || response.statusCode != 200) {
-                state = 'down';
-            }
-            status.description = state;
-            status.status = stateToStatus(state);
-            callback(null, status);
-        });
-    });
-});
-
-// High priority JIRA issues.
-
-// TODO: fix this
-
-//statusFetchers.push(function(callback) {
-//    var status = {
-//        name: 'P1/P2 JIRA Issues',
-//        link: 'https://jira.numenta.com/secure/RapidBoard.jspa?rapidView=40&quickFilter=418',
-//        category: categories.NUMENTA
-//    };
-//    console.log(JIRA_URL);
-//    proxyRequest.get(JIRA_URL, function(err, response) {
-//        if (err) { return callback(err); }
-//        console.log(response.body);
-//        var totalIssues = JSON.parse(response.body).total;
-//        status.description = totalIssues + ' issues';
-//        status.status = stateToStatus(totalIssues + ' issues');
-//        callback(null, status);
-//    });
-//});
-
 function requestHander(req, res) {
     async.parallel(statusFetchers, function(err, reports) {
         if (err) throw err;
+        reports = _.flatten(reports);
         reports = sortReportsByCategory(reports);
         res.end(mainTmpl({
             title: 'Numenta On-Call Status',

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "github": "^0.2.4",
     "handlebars": "^4.0.5",
     "lodash": "^4.0.0",
-    "request": "^2.67.0"
+    "request": "^2.75.0"
   }
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,5 +1,6 @@
 body {
     margin: 20px 30px;
+    font-family: Verdana, sans-serif;
 }
 
 table td, table th {
@@ -11,12 +12,45 @@ table td {
 }
 
 table th {
-    text-align: center;
+    text-align: right;
+    padding-right: 10px;
     font-size: x-large;
+}
+
+.panel-title {
+    font-size: 26pt;
 }
 
 .bootstrap-switch {
     position: absolute;
     top: 20px;
     right: 20px;
+}
+
+.status {
+    font-size: 14pt;
+    font-weight: bold;
+    min-width: 200px;
+    text-align: center;
+}
+
+.bg-success {
+    background-color: #dff0d8;
+    border: 1px solid green;
+}
+.bg-failure {
+    background-color: #f2dede;
+    border: 1px solid red;
+}
+.bg-error {
+    background-color: slategrey;
+    border: 1px solid #111;
+}
+.bg-pending {
+    background-color: #fcf8e3;
+    border: 1px solid orange;
+}
+.bg-unknown {
+    background-color: grey;
+    border: 1px solid #111;
 }

--- a/templates/main.hbt
+++ b/templates/main.hbt
@@ -46,15 +46,15 @@
                         <tbody>
                         {{#each this}}
                         <tr>
-                            <td>{{name}}</td>
-                            <td class="bg-{{status}}">
+                            <th>{{name}}</th>
+                            <td class="status bg-{{status}}">
                                 {{#if link}}
                                 <a target="_blank" href="{{link}}">
-                                    {{/if}}
+                                {{/if}}
 
                                     {{{description}}}
 
-                                    {{#if link}}
+                                {{#if link}}
                                 </a>
                                 {{/if}}
                             </td>


### PR DESCRIPTION
Adjusted to account for new pipeline structure. I propose this initially:

![screen shot 2016-10-08 at 1 41 06 pm](https://cloud.githubusercontent.com/assets/15566/19215812/31073934-8d5d-11e6-8e3e-4c4f27b1b2bf.png)

All statuses reflect state of `master` builds for each project. Each link goes to the specific build job that produced the status. 
